### PR TITLE
Fix image loading with fallback

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -370,12 +370,16 @@ html {
     overflow: hidden;
     height: 250px;
     background: var(--gray-100);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .product-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+    object-position: center;
     transition: all 0.5s ease;
 }
 

--- a/index.php
+++ b/index.php
@@ -307,8 +307,11 @@ $categories = $category->getAllCategories();
                     <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="<?php echo $productDelay; ?>">
                         <div class="product-card h-100 hover-lift">
                             <div class="product-image">
-                                <img src="<?php echo $product['image'] ?: 'assets/images/placeholder.jpg'; ?>" 
-                                     alt="<?php echo $product['name']; ?>" class="img-fluid">
+                                <img src="<?php echo $product['image'] ?: 'assets/images/placeholder.jpg'; ?>"
+                                     alt="<?php echo htmlspecialchars($product['name']); ?>"
+                                     class="img-fluid"
+                                     loading="lazy"
+                                     onerror="this.src='assets/images/placeholder.jpg';">
                                 <div class="product-overlay">
                                     <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $product['id']; ?>)">
                                         <i class="fas fa-shopping-cart"></i>

--- a/product.php
+++ b/product.php
@@ -163,7 +163,10 @@ unset($rp);
                         <div class="main-image mb-3">
                             <img src="<?php echo htmlspecialchars($mainImage); ?>"
                                  alt="<?php echo htmlspecialchars($productData['name']); ?>"
-                                 class="img-fluid rounded-custom shadow-lg" id="mainImage">
+                                 class="img-fluid rounded-custom shadow-lg"
+                                 id="mainImage"
+                                 loading="lazy"
+                                 onerror="this.src='assets/images/placeholder.jpg';">
                         </div>
                         <div class="thumbnail-images d-flex gap-2">
                             <?php if (!empty($productImages)): ?>
@@ -171,12 +174,16 @@ unset($rp);
                                     <img src="<?php echo htmlspecialchars($imgUrl); ?>"
                                          alt="Thumbnail"
                                          class="img-thumbnail thumbnail-img <?php echo $index === 0 ? 'active' : ''; ?>"
-                                         onclick="changeImage(this)">
+                                         loading="lazy"
+                                         onclick="changeImage(this)"
+                                         onerror="this.src='assets/images/placeholder.jpg';">
                                 <?php endforeach; ?>
                             <?php else: ?>
                                 <img src="<?php echo htmlspecialchars($mainImage); ?>"
                                      alt="Thumbnail" class="img-thumbnail thumbnail-img active"
-                                     onclick="changeImage(this)">
+                                     loading="lazy"
+                                     onclick="changeImage(this)"
+                                     onerror="this.src='assets/images/placeholder.jpg';">
                             <?php endif; ?>
                         </div>
                     </div>
@@ -455,9 +462,11 @@ unset($rp);
                                 <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up">
                                     <div class="product-card h-100 hover-lift">
                                         <div class="product-image">
-                                            <img src="<?php echo $related['image'] ?: 'assets/images/placeholder.jpg'; ?>" 
-                                                 alt="<?php echo htmlspecialchars($related['name']); ?>" 
-                                                 class="img-fluid">
+                                            <img src="<?php echo $related['image'] ?: 'assets/images/placeholder.jpg'; ?>"
+                                                 alt="<?php echo htmlspecialchars($related['name']); ?>"
+                                                 class="img-fluid"
+                                                 loading="lazy"
+                                                 onerror="this.src='assets/images/placeholder.jpg';">
                                             <div class="product-overlay">
                                                 <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $related['id']; ?>)" title="Agregar al carrito">
                                                     <i class="fas fa-shopping-cart"></i>

--- a/products.php
+++ b/products.php
@@ -265,9 +265,11 @@ $categories = $category->getAllCategories();
                         <div class="col-lg-3 col-md-6 mb-4 product-item" data-aos="fade-up" data-aos-delay="<?php echo $delay; ?>">
                             <div class="product-card h-100 hover-lift">
                                 <div class="product-image">
-                                    <img src="<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>" 
-                                         alt="<?php echo htmlspecialchars($prod['name']); ?>" 
-                                         class="img-fluid">
+                                    <img src="<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>"
+                                         alt="<?php echo htmlspecialchars($prod['name']); ?>"
+                                         class="img-fluid"
+                                         loading="lazy"
+                                         onerror="this.src='assets/images/placeholder.jpg';">
                                     <div class="product-overlay">
                                         <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $prod['id']; ?>)" title="Agregar al carrito">
                                             <i class="fas fa-shopping-cart"></i>


### PR DESCRIPTION
## Summary
- add lazy loading and error fallback to product images
- center images and use `object-fit: contain` for automatic resizing

## Testing
- `php test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6877ec5f9cbc8326af61c9d1175a52cb