### PR TITLE
Fix PHP tests for SQLite

### DIFF
--- a/test_sistema_completo.php
+++ b/test_sistema_completo.php
@@ -104,8 +104,15 @@ try {
     
     foreach ($tables as $table) {
         try {
-            $stmt = $pdo->query("SHOW TABLES LIKE '$table'");
-            if ($stmt->rowCount() > 0) {
+            if ($database && method_exists($database, 'isSQLite') && $database->isSQLite()) {
+                $stmt = $pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?");
+                $stmt->execute([$table]);
+                $exists = $stmt->fetch();
+            } else {
+                $stmt = $pdo->query("SHOW TABLES LIKE '$table'");
+                $exists = $stmt->fetch();
+            }
+            if ($exists) {
                 echo "<div class='text-success'>
                         <i class='fas fa-check-circle me-2'></i>
                         <strong>Tabla $table:</strong> ✅ Existe

--- a/verificacion_final_sistema.php
+++ b/verificacion_final_sistema.php
@@ -202,22 +202,22 @@ echo "</div>";
 echo "<div class='section'>";
 echo "<h2>📦 Funcionalidades de Productos</h2>";
 
-runTest("Obtener productos", function() {
+runTest("Obtener productos", function() use ($product) {
     $products = $product->getAllProducts(5);
     return is_array($products) ? true : false;
 });
 
-runTest("Obtener productos destacados", function() {
+runTest("Obtener productos destacados", function() use ($product) {
     $featured = $product->getFeaturedProducts(5);
     return is_array($featured) ? true : false;
 });
 
-runTest("Obtener categorías", function() {
+runTest("Obtener categorías", function() use ($category) {
     $categories = $category->getAllCategories();
     return is_array($categories) ? true : false;
 });
 
-runTest("Búsqueda de productos", function() {
+runTest("Búsqueda de productos", function() use ($product) {
     $search = $product->searchProducts('test', 5);
     return is_array($search) ? true : false;
 });


### PR DESCRIPTION
## Summary
- adapt table checks for SQLite
- capture variables in closures for product tests

## Testing
- `find . -name '*.php' -exec php -l {} \;`
- `USE_SQLITE=1 php test_system.php`
- `USE_SQLITE=1 php test_sistema_completo.php`
- `USE_SQLITE=1 php verificacion_final_sistema.php`


------
https://chatgpt.com/codex/tasks/task_b_6877f191ddb4832692f48bd5f88a6f96