### PR TITLE
Fix product image rendering for uploaded images

### DIFF
--- a/product.php
+++ b/product.php
@@ -17,13 +17,26 @@ if (!$productData) {
     exit;
 }
 
-// Procesar imágenes del producto
+// Procesar imágenes del producto asegurando compatibilidad con distintos formatos
 $productImages = [];
 if (!empty($productData['images'])) {
-    $productImages = json_decode($productData['images'], true);
-    if (json_last_error() !== JSON_ERROR_NONE) {
-        $productImages = [];
+    $decoded = json_decode($productData['images'], true);
+    if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+        foreach ($decoded as $img) {
+            if (is_array($img)) {
+                $productImages[] = $img['original'] ?? ($img['thumbnail'] ?? '');
+            } elseif (is_string($img)) {
+                $productImages[] = $img;
+            }
+        }
+        // Limpiar valores vacíos
+        $productImages = array_values(array_filter($productImages));
     }
+}
+
+// Fallback si no hay imágenes válidas
+if (empty($productImages)) {
+    $productImages[] = Product::getImagePath($productData);
 }
 
 $mainImage = $productImages[0] ?? 'assets/images/placeholder.jpg';


### PR DESCRIPTION
## Summary
- ensure product page handles images stored as objects or strings
- parse image JSON more robustly

## Testing
- `USE_SQLITE=1 php check_database_connection.php`
- `USE_SQLITE=1 php -f test_system.php`
- `USE_SQLITE=1 php -f test_upload_simple.php`


------
https://chatgpt.com/codex/tasks/task_b_68780c0c31788326959cae83d60e013c