### PR TITLE
Fix image checks and cleanup admin script

### DIFF
--- a/admin/products.php
+++ b/admin/products.php
@@ -775,23 +775,6 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
             }
         }
         
-        function updateImagesJson() {
-            const previews = document.querySelectorAll('.image-preview');
-            previews.forEach(preview => {
-                const images = Array.from(preview.querySelectorAll('img')).map(img => {
-                    // Extraer la ruta relativa del src
-                    let src = img.src;
-                    if (src.includes('../')) {
-                        src = src.split('../')[1];
-                    }
-                    return src;
-                });
-                const hiddenInput = preview.parentElement.querySelector('[id$="ImagesJson"]');
-                if (hiddenInput) {
-                    hiddenInput.value = JSON.stringify(images);
-                }
-            });
-        }
     </script>
 </body>
 </html>

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -324,7 +324,7 @@ class Product {
                     
                     // Verificar si es una ruta local válida
                     $localPath = __DIR__ . '/../' . ltrim($firstImage, '/');
-                    if (file_exists($localPath) && filesize($localPath) > 100) {
+                    if (file_exists($localPath) && filesize($localPath) > 0) {
                         return $firstImage;
                     }
                 }
@@ -338,7 +338,7 @@ class Product {
             foreach ($extensions as $ext) {
                 $path = "assets/images/products/{$slug}.{$ext}";
                 $fullPath = __DIR__ . '/../' . $path;
-                if (file_exists($fullPath) && filesize($fullPath) > 100) {
+                if (file_exists($fullPath) && filesize($fullPath) > 0) {
                     return $path;
                 }
             }


### PR DESCRIPTION
## Summary
- relax file size check in `Product::getImagePath`
- rely on shared `updateImagesJson()` from `admin.js`

## Testing
- `php -l classes/Product.php`
- `php -l admin/products.php`
- `find . -name '*.php' -maxdepth 2 | xargs -I{} php -l {}`
- `php test_upload_simple.php`
- `php test_system.php` *(fails: No such file or directory)*
- `php test_upload.php`

------
https://chatgpt.com/codex/tasks/task_b_68780fd2917c8333901a4a1f3a0abfc5