### PR TITLE
Fix undefined array keys on products page

### DIFF
--- a/products.php
+++ b/products.php
@@ -281,12 +281,12 @@ $categories = $category->getAllCategories();
                                             <i class="fas fa-heart"></i>
                                         </button>
                                     </div>
-                                    <?php if ($prod['discount_percentage'] > 0): ?>
+                                    <?php if (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0): ?>
                                         <span class="badge bg-danger position-absolute top-0 start-0 m-2 pulse">
                                             -<?php echo $prod['discount_percentage']; ?>%
                                         </span>
                                     <?php endif; ?>
-                                    <?php if ($prod['featured']): ?>
+                                    <?php if (isset($prod['featured']) && $prod['featured']): ?>
                                         <span class="badge bg-warning position-absolute top-0 end-0 m-2">
                                             <i class="fas fa-star"></i> Destacado
                                         </span>
@@ -321,7 +321,7 @@ $categories = $category->getAllCategories();
                                     
                                     <div class="d-flex justify-content-between align-items-center mb-3">
                                         <div class="price">
-                                            <?php if ($prod['discount_percentage'] > 0): ?>
+                                            <?php if (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0): ?>
                                                 <span class="text-decoration-line-through text-muted me-2">
                                                     $<?php echo number_format($prod['price'], 0, ',', '.'); ?>
                                                 </span>
@@ -343,7 +343,7 @@ $categories = $category->getAllCategories();
                                             <i class="fas fa-cart-plus me-2"></i>
                                             Agregar al Carrito
                                         </button>
-                                        <a href="https://wa.me/593983015307?text=Hola%2C%20quiero%20comprar%20el%20producto:%20<?php echo urlencode($prod['name']); ?>%20-%20$<?php echo number_format($prod['discount_percentage'] > 0 ? $prod['price'] * (1 - $prod['discount_percentage'] / 100) : $prod['price'], 0, ',', '.'); ?>%20-%20AlquimiaTechnologic" 
+                                        <a href="https://wa.me/593983015307?text=Hola%2C%20quiero%20comprar%20el%20producto:%20<?php echo urlencode($prod['name']); ?>%20-%20$<?php echo number_format((isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0) ? $prod['price'] * (1 - $prod['discount_percentage'] / 100) : $prod['price'], 0, ',', '.'); ?>%20-%20AlquimiaTechnologic"
                                            class="btn btn-success btn-sm hover-lift" target="_blank">
                                             <i class="fab fa-whatsapp me-2"></i>
                                             Comprar por WhatsApp


### PR DESCRIPTION
## Summary
- avoid undefined array key warnings in `products.php`

## Testing
- `php -l products.php`
- `php test_system.php` *(fails: SQLSTATE[HY000] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68781577e914833381174e665f2e5dd6