### PR TITLE
Allow hero image config

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -324,6 +324,9 @@ function handleFileUpload(source, preview, folder = 'products') {
                     } else if (hiddenInput.id === 'faviconImagesJson') {
                         const urlInput = document.getElementById('faviconUrl');
                         if (urlInput) urlInput.value = images[0] || '';
+                    } else if (hiddenInput.id === 'heroImagesJson') {
+                        const urlInput = document.getElementById('heroImageUrl');
+                        if (urlInput) urlInput.value = images[0] || '';
                     }
                 } catch (e) {
                     console.error('JSON parse error:', e);
@@ -417,6 +420,9 @@ function updateImagesJson() {
                 if (urlInput) urlInput.value = images[0] || '';
             } else if (hiddenInput.id === 'faviconImagesJson') {
                 const urlInput = document.getElementById('faviconUrl');
+                if (urlInput) urlInput.value = images[0] || '';
+            } else if (hiddenInput.id === 'heroImagesJson') {
+                const urlInput = document.getElementById('heroImageUrl');
                 if (urlInput) urlInput.value = images[0] || '';
             }
         }

--- a/config/config.php
+++ b/config/config.php
@@ -88,6 +88,26 @@ function generateSlug($string) {
     return trim($slug, '-');
 }
 
+// Obtener un valor de la configuración del sitio almacenado en data/settings.json
+function getSiteSetting($key, $default = null) {
+    static $siteSettings = null;
+    if ($siteSettings === null) {
+        $settingsFile = __DIR__ . '/../data/settings.json';
+        if (file_exists($settingsFile)) {
+            $json = file_get_contents($settingsFile);
+            $data = json_decode($json, true);
+            if (is_array($data)) {
+                $siteSettings = $data;
+            } else {
+                $siteSettings = [];
+            }
+        } else {
+            $siteSettings = [];
+        }
+    }
+    return $siteSettings[$key] ?? $default;
+}
+
 // Configuración de errores (solo para desarrollo)
 error_reporting(E_ALL);
 ini_set('display_errors', 1);

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,0 +1,18 @@
+{
+  "site_name": "AlquimiaTechnologic",
+  "site_description": "Especialistas en software personalizado, aceites esenciales y figuras artesanales",
+  "hero_image_url": "assets/images/placeholder.jpg",
+  "contact_email": "kevinmoyolema13@gmail.com",
+  "contact_phone": "+593 983015307",
+  "whatsapp_number": "+593 983015307",
+  "address": "Ecuador",
+  "google_maps_embed": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.7964691869!2d-78.60053978945571!3d-1.2967735986854487!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x91d3833075ab6891%3A0xc5bed5e18459cf30!2sALQUIMIA%20ESENCIAL!5e0!3m2!1ses!2snl!4v1752552300301!5m2!1ses!2snl",
+  "facebook_url": "https://facebook.com/alquimiatechnologic",
+  "instagram_url": "https://instagram.com/alquimiatechnologic",
+  "whatsapp_url": "https://wa.me/593983015307",
+  "logo_url": "",
+  "favicon_url": "",
+  "maintenance_mode": false,
+  "allow_registration": true,
+  "email_notifications": true
+}

--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ foreach ($featuredProducts as &$fp) {
 }
 unset($fp);
 $categories = $category->getAllCategories();
+$heroImage = getSiteSetting('hero_image_url', 'assets/images/placeholder.jpg');
 ?>
 
 <!DOCTYPE html>
@@ -183,7 +184,7 @@ $categories = $category->getAllCategories();
                 </div>
                 
                 <div class="col-lg-6 hero-image text-center" data-aos="fade-left" data-aos-duration="1000" data-aos-delay="200">
-                    <img src="assets/images/placeholder.jpg"
+                    <img src="<?php echo htmlspecialchars($heroImage); ?>"
                          alt="Tecnología y Innovación" class="img-fluid">
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow fetching site settings via helper
- load hero image setting on homepage
- support hero image upload and preview in admin panel
- handle hero image setting in admin JS
- store initial site settings in `data/settings.json`

## Testing
- `php test_system.php` *(fails: Error de conexión)*
- `php -l config/config.php`
- `php -l index.php`
- `php -l admin/settings.php`
- `php -l assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_b_687818f3ae748333a109a8f43b28b41e