### PR TITLE
Fix hero image display

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -1,7 +1,7 @@
 {
   "site_name": "AlquimiaTechnologic",
   "site_description": "Especialistas en software personalizado, aceites esenciales y figuras artesanales",
-  "hero_image_url": "assets/images/placeholder.jpg",
+  "hero_image_url": "assets/images/settings/ChatGPT_Image_15_jul_2025__05_37_35_p_m__6877cb7aeb533.png",
   "contact_email": "kevinmoyolema13@gmail.com",
   "contact_phone": "+593 983015307",
   "whatsapp_number": "+593 983015307",

--- a/index.php
+++ b/index.php
@@ -195,16 +195,7 @@ $heroImage = getSiteSetting('hero_image_url', 'assets/images/placeholder.jpg');
     <section class="section bg-light">
         <div class="container">
             <div class="row">
-                <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="100">
-                    <div class="text-center">
-                        <div class="feature-icon mb-3">
-                            <i class="fas fa-shipping-fast text-primary fs-1"></i>
-                        </div>
-                        <h5 class="fw-bold">Envío Gratis</h5>
-                        <p class="text-muted">En pedidos superiores a $50.000</p>
-                    </div>
-                </div>
-                <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
+                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
                     <div class="text-center">
                         <div class="feature-icon mb-3">
                             <i class="fas fa-shield-alt text-success fs-1"></i>
@@ -213,7 +204,7 @@ $heroImage = getSiteSetting('hero_image_url', 'assets/images/placeholder.jpg');
                         <p class="text-muted">Pagos 100% seguros y protegidos</p>
                     </div>
                 </div>
-                <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
+                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
                     <div class="text-center">
                         <div class="feature-icon mb-3">
                             <i class="fas fa-headset text-info fs-1"></i>
@@ -222,7 +213,7 @@ $heroImage = getSiteSetting('hero_image_url', 'assets/images/placeholder.jpg');
                         <p class="text-muted">Atención al cliente siempre disponible</p>
                     </div>
                 </div>
-                <div class="col-lg-3 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="400">
+                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="400">
                     <div class="text-center">
                         <div class="feature-icon mb-3">
                             <i class="fas fa-undo text-warning fs-1"></i>


### PR DESCRIPTION
## Summary
- use hero image from settings on the home page
- remove shipping promo text

## Testing
- `php -l index.php`
- `php -l admin/settings.php`
- `npm test` in `api`
- `php test_sistema_completo.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68781d78fce48333ab1a06eb9ca8a5c4